### PR TITLE
Update server shutdown to utilize defined context

### DIFF
--- a/cmd/onionbox/main.go
+++ b/cmd/onionbox/main.go
@@ -65,7 +65,7 @@ func main() {
 		ob.Quit()
 	}
 	defer func() { // Proper server shutdown when program ends
-		if err = ob.Server.Shutdown(context.Background()); err != nil {
+		if err = ob.Server.Shutdown(ctx); err != nil {
 			ob.Logf("Error shutting down onionbox server: %v", err)
 			ob.Quit()
 		}


### PR DESCRIPTION
This PR updates the onionbox server to shutdown utilizing the defined context at the program's start which includes a 3 minute timeout instead of using `context.Backgroudn()`.